### PR TITLE
removed update channel from ovsclient

### DIFF
--- a/ovsclient.go
+++ b/ovsclient.go
@@ -67,7 +67,6 @@ type ovsClient struct {
 }
 
 var client *ovsClient
-var update chan *libovsdb.TableUpdates
 var cache map[string]map[string]libovsdb.Row
 var ovsclient *ovsClient
 
@@ -109,7 +108,6 @@ func GetOVSClient(contype, endpoint string) (OvsClient, error) {
 	var notfr notifier
 	dbclient.Register(notfr)
 
-	update = make(chan *libovsdb.TableUpdates)
 	cache = make(map[string]map[string]libovsdb.Row)
 
 	client = &ovsClient{dbClient: dbclient}
@@ -160,7 +158,6 @@ type notifier struct {
 
 func (n notifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
 	populateCache(tableUpdates)
-	update <- &tableUpdates
 }
 func (n notifier) Locked([]interface{}) {
 }


### PR DESCRIPTION
II think that unused update channel in ovsclient.go was causing memory leak. I have execution comparisson with and without it:

https://gist.github.com/tornyak/d697b41e8da935f77dccf0ba3c93b231
